### PR TITLE
correcting typo in dataset size and removing obsolete json-ld elements

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -2,27 +2,21 @@
     "title": "SIMON",
     "description": "The Single Individual volunteer for Multiple Observations across Networks (SIMON) MRI dataset is a sample of convenience of one ambidextrous healthy male aged between 29 and 46 years old, scanned in 73 sessions at multiple sites and with various scanner models",
     "dates": [
-	{
-            "@type": "Date",
+		{
             "date": "2001-09-20 00:00:00",
             "type": {
-                "@type": "Annotation",
                 "value": "start date"
             }
-	},
-	{
-            "@type": "Date",
+		},
+		{
             "date": "2018-09-18 00:00:00",
             "type": {
-                "@type": "Annotation",
                 "value": "end date"
             }
-	}
-
+		}
     ],
     "creators": [
         {
-            "@type": "Organization",
             "name": "Laboratoire MEDICS"
         }
     ],
@@ -40,17 +34,14 @@
     "privacy": "open",
     "distributions": [
         {
-            "@type": "DatasetDistribution",
             "formats": [
                 "NIfTI"
             ],
-            "size" : 84,
+            "size" : 8.4,
             "unit" : {
-                "@type": "Annotation",
                 "value": "GB"
             },
             "access" : {
-                "@type": "Access",
                 "landingPage" : "http://fcon_1000.projects.nitrc.org/indi/retro/SIMON.html",
 				"authorizations": [
 					{
@@ -62,147 +53,112 @@
     ],
     "isAbout": [
         {
-            "@type": "BiologicalEntity",
             "name": "adult human"
         }
     ],
     "licenses": [
         {
-            "@type": "License",
             "name": "CC BY-SA"
         }
     ],
     "aggregation": "instance of dataset",
     "acknowledges" : [
         {
-            "@type": "Grant",
-            "name": "",
             "funders": [
                 {
-                    "@type": "Organization",
                     "name": "Fonds de Recheche du Québec - Santé",
                     "abbreviation": "FRQ-S"
                 },
                 {
-                    "@type": "Organization",
                     "name": "Consortium pour l'Identification précoce de la Maladie d'Alzheimer - Québec",
                     "abbreviation": "CIMA-Q"
                 },
                 {
-                    "@type": "Organization",
                     "name": "Canadian Consortium on Neurodegeneration in Aging",
                     "abbreviation": "CCNA"
                 },
                 {
-                    "@type": "Organization",
                     "name": "Consortium Canadien en Neurodégénérescence associée au Vieillissement",
                     "abbreviation": "CCNA"
                 },
                 {
-                    "@type": "Organization",
                     "name": "Ontario Neurodegenerative Disease Research Initiative",
                     "abbreviation": "ONDRI"
                 },
                 {
-                    "@type": "Organization",
                     "name": "Pfizer Canada Innovation Fund"
                 },
                 {
-                    "@type": "Organization",
                     "name": "Ontario Brain Institute Foundation"
                 },
                 {
-                    "@type": "Organization",
                     "name": "Canada Fund for Innovation",
                     "abbreviation": "CFI"
                 },
                 {
-                    "@type": "Organization",
                     "name": "Fond Canadien de l'Innovation",
                     "abbreviation": "FCI"
                 }
-                 
             ]
         }
     ],
     "dimensions": [
         {
-            "@type": "Dimension",
             "name" : {
-                "@type": "Annotation",
                 "value": "T1w"
             }
         },
         {
-            "@type": "Dimension",
             "name" : {
-                "@type": "Annotation",
                 "value": "T1"
             }
         },
         {
-            "@type": "Dimension",
             "name" : {
-                "@type": "Annotation",
                 "value": "T2"
             }
         },
         {
-            "@type": "Dimension",
             "name" : {
-                "@type": "Annotation",
                 "value": "T2*"
             }
         },
         {
-            "@type": "Dimension",
             "name" : {
-                "@type": "Annotation",
                 "value": "PDw"
             }
         },
         {
-            "@type": "Dimension",
             "name" : {
-                "@type": "Annotation",
                 "value": "SWI"
             }
         },
         {
-            "@type": "Dimension",
             "name" : {
-                "@type": "Annotation",
                 "value": "ASL"
             }
         },
         {
-            "@type": "Dimension",
             "name" : {
-                "@type": "Annotation",
                 "value": "age at scan"
             }
         },
         {
-            "@type": "Dimension",
             "name" : {
-                "@type": "Annotation",
                 "value": "resting state fMRI"
             }
         }
     ],
     "keywords": [
         {
-            "@type": "Annotation",
             "value": "Phantom"
-        },	
+        },
         {
-            "@type": "Annotation",
             "value": "MRI"
         }
     ],
     "primaryPublications": [
         {
-            "@type": "Publication",
             "title": "The Canadian Dementia Imaging Protocol: Harmonizing National Cohorts",
             "publicationVenue": "Journal of Magnetic Resonance Imaging, volume 49, Issue 2",
             "authorsList": "Simon Duchesne PhD, Isabelle Chouinard MRT, Olivier Potvin PhD, Vladimir S. Fonov PhD, April Khademi PhD, Robert Bartha PhD, Pierre Bellec PhD, D. Louis Collins PhD, Maxime Descoteaux PhD, Rick Hoge PhD, Cheryl R. McCreary PhD, Joel Ramirez PhD, Christopher J.M. Scott BScH, Eric E. Smith MD, Stephen C. Strother PhD, Sandra E. Black MD for the CIMA‐Q group and the CCNA group"
@@ -268,7 +224,7 @@
     {
       "category": "origin_city",
       "values": [
-        { 
+        {
           "value": "Quebec"
         }
       ]
@@ -276,7 +232,7 @@
     {
       "category": "origin_province",
       "values": [
-        { 
+        {
           "value": "Quebec"
         }
       ]
@@ -284,7 +240,7 @@
     {
       "category": "origin_country",
       "values": [
-        { 
+        {
           "value": "Canada"
         }
       ]

--- a/DATS.json
+++ b/DATS.json
@@ -29,11 +29,11 @@
     "types": [
         {
             "value": "MRI",
-            "valueIRI": ""
+			"valueIRI": "http://uri.interlex.org/ilx_0779748"
         },
         {
             "value": "Quality Control Subject",
-            "valueIRI": "http://uri.interlex.org/base/ilx_0381893"
+            "valueIRI": "http://uri.interlex.org/ilx_0381893"
         }
     ],
     "version": "1.0",


### PR DESCRIPTION
This PR updates the DATS.json file to remove obsolete partial translation into json-ld and correct the dataset size value, which was out by an order of magnitude.